### PR TITLE
Added cluster roles and a lab user group

### DIFF
--- a/charts/templates/datascienceproject/rolebindings.yaml
+++ b/charts/templates/datascienceproject/rolebindings.yaml
@@ -15,31 +15,4 @@ roleRef:
   kind: ClusterRole
   name: admin
 ---
-# to edit/view monitoring
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: user{{ $attendee }}-monitoring-edit
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: monitoring-edit
-subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: user{{ $attendee }}
----
-# to view logs
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: user{{ $attendee }}-view-application-logs
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-logging-application-view
-subjects:
-- kind: User
-  name: user{{ $attendee }}
-  apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/charts/templates/rbacs/clusterRoles.yaml
+++ b/charts/templates/rbacs/clusterRoles.yaml
@@ -1,0 +1,58 @@
+# Give our users view access to specific resources in the cluster for possible debugging.
+# This can be extended to include other resources as needed.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: lab-user-viewer
+rules:
+  - apiGroups: ["*"]
+    resources: ["alertmanagers"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Group
+metadata:
+  name: lab-attendees
+users:
+{{- $attendees := (.Values.attendees | int) }}
+{{- range $attendee := until $attendees }}
+  - user{{ $attendee }}-jukebox
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: lab-user-viewer-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: lab-user-viewer
+subjects:
+- kind: Group
+  name: lab-attendees
+  apiGroup: rbac.authorization.k8s.io
+# to edit/view monitoring
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: lab-user-monitoring-edit
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: monitoring-edit
+subjects:
+- kind: Group
+  name: lab-attendees
+---
+# to view logs
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: lab-user-view-application-logs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-logging-application-view
+subjects:
+- kind: Group
+  name: lab-attendees


### PR DESCRIPTION
Created a `Group` here so that it is easier to add future ClusterRoles if required, and gave view access to `AlertManager` so folks should be able to debug Alerting issues if they run into them again.

The relevant output of the helm chart is below. I believe this should work fine, but I have not gotten a chance to validate it:

```
# Source: ml500-base/templates/rbacs/ClusterRoles.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: lab-user-viewer-binding
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: lab-user-viewer
subjects:
- kind: Group
  name: lab-attendees
  apiGroup: rbac.authorization.k8s.io
---
# to edit/view monitoring
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: lab-user-monitoring-edit
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: monitoring-edit
subjects:
- kind: Group
  name: lab-attendees
---
# Source: ml500-base/templates/rbacs/ClusterRoles.yaml
# to view logs
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: lab-user-view-application-logs
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: cluster-logging-application-view
subjects:
- kind: Group
  name: lab-attendees
---
# Source: ml500-base/templates/rbacs/ClusterRoles.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Group
metadata:
  name: lab-attendees
users:
  - user0-jukebox
  - user1-jukebox
  - user2-jukebox
  - user3-jukebox
  - user4-jukebox
  - user5-jukebox
  - user6-jukebox
  - user7-jukebox
  - user8-jukebox
  - user9-jukebox
---
# Source: ml500-base/templates/rbacs/ClusterRoles.yaml
# Give our users view access to specific resources in the cluster for possible debugging.
# This can be extended to include other resources as needed.
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: lab-user-viewer
rules:
  - apiGroups: ["*"]
    resources: ["alertmanagers"]
    verbs: ["get", "list", "watch"]
---
```