### PR TITLE
Added wait for gitops installation and fixed attendees source value

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,8 @@
 # Install the operators
 helm upgrade --install ml500-base operators --namespace ml500 --create-namespace
 
+oc wait --for=jsonpath='{.status.availableReplicas}'=1 -n openshift-gitops deployment/cluster
+
 # Install the toolings
 helm upgrade --install ml500-toolings toolings --namespace ml500 --create-namespace
 
@@ -19,7 +21,7 @@ oc -n openshift-user-workload-monitoring patch configmap user-workload-monitorin
 oc patch config.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge
 
 # Make ArgoCD cluster wide
-attendees=`grep attendees charts/values.yaml | cut -d':' -f2`
+attendees=`grep attendees student-content/values.yaml | cut -d':' -f2`
  for ((i=0; i<=$attendees; i++))
  do
    if [ $i -eq 1 ]; then


### PR DESCRIPTION
Added the `oc wait` command on line 5 as the installation of the `ml500-toolings` chart would fail due to the missing ArgoCD CRD:

`Error: unable to build kubernetes objects from release manifest: [resource mapping not found for name: "argocd" namespace: "user1-toolings" from "": no matches for kind "ArgoCD" in version "argoproj.io/v1beta1"
`

Also fixed the attendees variable on line 24:

`grep: charts/values.yaml: No such file or directory`