### PR TITLE
Fix sealed-secrets helm repo URL

### DIFF
--- a/operators/Chart.yaml
+++ b/operators/Chart.yaml
@@ -11,6 +11,6 @@ maintainers:
   - name: ckavili
 dependencies:
   - name: sealed-secrets
-    version: "2.17.2"
-    repository: https://bitnami-labs.github.io/sealed-secrets
+    version: "2.18.6"
+    repository: https://bitnami.github.io/sealed-secrets
     condition: sealed-secrets.enabled

--- a/operators/Chart.yaml
+++ b/operators/Chart.yaml
@@ -11,6 +11,6 @@ maintainers:
   - name: ckavili
 dependencies:
   - name: sealed-secrets
-    version: "2.18.6"
+    version: "2.17.2"
     repository: https://bitnami.github.io/sealed-secrets
     condition: sealed-secrets.enabled


### PR DESCRIPTION
The old `bitnami-labs.github.io/sealed-secrets` helm repo returns 404. Updated to `bitnami.github.io/sealed-secrets` and bumped chart to 2.18.6.